### PR TITLE
pass the captured username to resolveHomeUser()

### DIFF
--- a/packages/bash-parser/src/modes/posix/rules/tilde-expanding.js
+++ b/packages/bash-parser/src/modes/posix/rules/tilde-expanding.js
@@ -4,13 +4,13 @@ const tokens = require('../../../utils/tokens');
 
 const replace = (text, resolveHomeUser) => {
 	let replaced = false;
-	let result = text.replace(/^~[^\/]*\//, (match, p1) => {
+	let result = text.replace(/^~([^\/]*)\//, (match, p1) => {
 		replaced = true;
 		return resolveHomeUser(p1 || null) + '/';
 	});
 	// console.log({result, replaced})
 	if (!replaced) {
-		result = text.replace(/^~.*$/, (match, p1) => {
+		result = text.replace(/^~(.*)$/, (match, p1) => {
 			return resolveHomeUser(p1 || null);
 		});
 	}


### PR DESCRIPTION
Looks like the username argument to ```resolveHomeUser()``` is always ```null```. This fixes that.