### PR TITLE
Delinting (Minor test-file formatting fixes to pass tests)

### DIFF
--- a/test/test-loc.js
+++ b/test/test-loc.js
@@ -1,46 +1,46 @@
-"use strict";
+'use strict';
 
-const test = require("ava");
-const bashParser = require("../src");
-const mkloc = require("./_utils").mkloc2;
-const utils = require("./_utils");
+const test = require('ava');
+const bashParser = require('../src');
+const mkloc = require('./_utils').mkloc2;
+const utils = require('./_utils');
 
 /* eslint-disable camelcase */
-test("syntax error contains line number", async t => {
-	const error = t.throws(() => bashParser("ecoh\necho <"));
+test('syntax error contains line number', async t => {
+	const error = t.throws(() => bashParser('ecoh\necho <'));
 	t.true(
 		error.message.startsWith(
-			"Error: Parse error on line 2: Unexpected 'EOF'"
+			'Error: Parse error on line 2: Unexpected \'EOF\''
 		)
 	);
 });
 
-test("AST can include loc", t => {
-	const result = bashParser("echo", { insertLOC: true });
+test('AST can include loc', t => {
+	const result = bashParser('echo', {insertLOC: true});
 	// utils.logResults(result)
 	utils.checkResults(t, result.commands[0].name, {
-		type: "Word",
-		text: "echo",
+		type: 'Word',
+		text: 'echo',
 		loc: mkloc(1, 1, 1, 4, 0, 3)
 	});
 });
 
-test("subshell can include loc", t => {
-	const result = bashParser("(echo)", { insertLOC: true });
+test('subshell can include loc', t => {
+	const result = bashParser('(echo)', {insertLOC: true});
 	// utils.logResults(result);
 	utils.checkResults(t, result, {
-		type: "Script",
+		type: 'Script',
 		commands: [
 			{
-				type: "Subshell",
+				type: 'Subshell',
 				list: {
-					type: "CompoundList",
+					type: 'CompoundList',
 					commands: [
 						{
-							type: "Command",
+							type: 'Command',
 							name: {
-								text: "echo",
-								type: "Word",
+								text: 'echo',
+								type: 'Word',
 								loc: mkloc(1, 2, 1, 5, 1, 4)
 							},
 							loc: mkloc(1, 2, 1, 5, 1, 4)
@@ -55,27 +55,27 @@ test("subshell can include loc", t => {
 	});
 });
 
-test("double command with only name", t => {
-	const result = bashParser("echo; ciao;", { insertLOC: true });
+test('double command with only name', t => {
+	const result = bashParser('echo; ciao;', {insertLOC: true});
 	// utils.logResults(result);
 	utils.checkResults(t, result, {
-		type: "Script",
+		type: 'Script',
 		loc: mkloc(1, 1, 1, 10, 0, 9),
 		commands: [
 			{
-				type: "Command",
+				type: 'Command',
 				name: {
-					type: "Word",
-					text: "echo",
+					type: 'Word',
+					text: 'echo',
 					loc: mkloc(1, 1, 1, 4, 0, 3)
 				},
 				loc: mkloc(1, 1, 1, 4, 0, 3)
 			},
 			{
-				type: "Command",
+				type: 'Command',
 				name: {
-					type: "Word",
-					text: "ciao",
+					type: 'Word',
+					text: 'ciao',
 					loc: mkloc(1, 7, 1, 10, 6, 9)
 				},
 				loc: mkloc(1, 7, 1, 10, 6, 9)
@@ -84,61 +84,61 @@ test("double command with only name", t => {
 	});
 });
 
-test("loc are composed by all tokens", t => {
-	const result = bashParser("echo 42", { insertLOC: true });
+test('loc are composed by all tokens', t => {
+	const result = bashParser('echo 42', {insertLOC: true});
 	// console.log(JSON.stringify(result, null, 4));
 	utils.checkResults(t, result.commands[0], {
-		type: "Command",
+		type: 'Command',
 		name: {
-			type: "Word",
-			text: "echo",
+			type: 'Word',
+			text: 'echo',
 			loc: mkloc(1, 1, 1, 4, 0, 3)
 		},
 		loc: mkloc(1, 1, 1, 7, 0, 6),
 		suffix: [
 			{
-				type: "Word",
-				text: "42",
+				type: 'Word',
+				text: '42',
 				loc: mkloc(1, 6, 1, 7, 5, 6)
 			}
 		]
 	});
 });
 
-test("loc works with multiple newlines", t => {
-	const result = bashParser("\n\n\necho 42", { insertLOC: true });
+test('loc works with multiple newlines', t => {
+	const result = bashParser('\n\n\necho 42', {insertLOC: true});
 	utils.checkResults(t, result.commands[0], {
-		type: "Command",
+		type: 'Command',
 		name: {
-			type: "Word",
-			text: "echo",
+			type: 'Word',
+			text: 'echo',
 			loc: mkloc(4, 1, 4, 4, 3, 6)
 		},
 		loc: mkloc(4, 1, 4, 7, 3, 9),
 		suffix: [
 			{
-				type: "Word",
-				text: "42",
+				type: 'Word',
+				text: '42',
 				loc: mkloc(4, 6, 4, 7, 8, 9)
 			}
 		]
 	});
 });
 
-test("loc with LINEBREAK_IN statement", t => {
+test('loc with LINEBREAK_IN statement', t => {
 	const cmd = `for x
 	in ; do
 	echo $x;
 done
 `;
 
-	const result = bashParser(cmd, { insertLOC: true });
+	const result = bashParser(cmd, {insertLOC: true});
 	// utils.logResults(result)
 	const expected = {
-		type: "For",
+		type: 'For',
 		name: {
-			text: "x",
-			type: "Name",
+			text: 'x',
+			type: 'Name',
 			loc: {
 				start: {
 					col: 5,
@@ -153,13 +153,13 @@ done
 			}
 		},
 		do: {
-			type: "CompoundList",
+			type: 'CompoundList',
 			commands: [
 				{
-					type: "Command",
+					type: 'Command',
 					name: {
-						text: "echo",
-						type: "Word",
+						text: 'echo',
+						type: 'Word',
 						loc: {
 							start: {
 								col: 2,
@@ -187,18 +187,18 @@ done
 					},
 					suffix: [
 						{
-							text: "$x",
+							text: '$x',
 							expansion: [
 								{
 									loc: {
 										start: 0,
 										end: 1
 									},
-									parameter: "x",
-									type: "ParameterExpansion"
+									parameter: 'x',
+									type: 'ParameterExpansion'
 								}
 							],
-							type: "Word",
+							type: 'Word',
 							loc: {
 								start: {
 									col: 7,
@@ -245,27 +245,27 @@ done
 	utils.checkResults(t, result.commands[0], expected);
 });
 
-test("loc in multi line commands", t => {
-	const result = bashParser("echo;\nls;\n", { insertLOC: true });
+test('loc in multi line commands', t => {
+	const result = bashParser('echo;\nls;\n', {insertLOC: true});
 	// utils.logResults(result);
 	utils.checkResults(t, result, {
 		loc: mkloc(1, 1, 2, 2, 0, 7),
-		type: "Script",
+		type: 'Script',
 		commands: [
 			{
-				type: "Command",
+				type: 'Command',
 				name: {
-					type: "Word",
-					text: "echo",
+					type: 'Word',
+					text: 'echo',
 					loc: mkloc(1, 1, 1, 4, 0, 3)
 				},
 				loc: mkloc(1, 1, 1, 4, 0, 3)
 			},
 			{
-				type: "Command",
+				type: 'Command',
 				name: {
-					type: "Word",
-					text: "ls",
+					type: 'Word',
+					text: 'ls',
 					loc: mkloc(2, 1, 2, 2, 6, 7)
 				},
 				loc: mkloc(2, 1, 2, 2, 6, 7)


### PR DESCRIPTION
`npm run build && npm test` fails on error level style violation:

  test/test-loc.js:1:1
  ✖    1:1   Strings must use singlequote.      quotes
  ✖    3:22  Strings must use singlequote.      quotes
  ✖    4:28  Strings must use singlequote.      quotes
  ✖    5:23  Snpm ERR! code ELIFECYCLE